### PR TITLE
Remove restriction on max parallel Scala Compile Server threads

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/compiler/ScalaCompileServerForm.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/compiler/ScalaCompileServerForm.java
@@ -72,7 +72,7 @@ public class ScalaCompileServerForm implements Configurable {
         mySdkPanel.add(UI.PanelFactory.panel(myCompilationServerSdk).withTooltip(ScalaBundle.message("compile.server.description")).createPanel(), BorderLayout.CENTER);
 
         myShutdownDelay.setModel(new SpinnerNumberModel(mySettings.COMPILE_SERVER_SHUTDOWN_DELAY, 0, 24 * 60, 1));
-        myParallelism.setModel(new SpinnerNumberModel(mySettings.COMPILE_SERVER_PARALLELISM, 1, 6, 1));
+        myParallelism.setModel(new SpinnerNumberModel(mySettings.COMPILE_SERVER_PARALLELISM, 1, 9999, 1));
 
         updateJvmSettingsPanel();
     }


### PR DESCRIPTION
I have more than 6 cores and because of that `sbt compile` finishes faster than an IDEA build on my machine purely due to parallelism. I believe the restriction of maximum 6 threads may be a tad too low and could probably be increased or completely unrestricted. (I chose to do the latter in this change)
